### PR TITLE
feat: Add LSP features and initial debugger support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "anyhow"
+version = "1.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +74,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "d_dap"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "d_compiler",
+ "dap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "d_lsp"
 version = "0.1.0"
 dependencies = [
@@ -76,6 +93,17 @@ dependencies = [
  "lsp-types",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "dap"
+version = "0.4.1-alpha1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c7fc89d334ab745ba679f94c7314c9b17ecdcd923c111df6206e9fd7729fa9"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -455,6 +483,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,6 @@ members = [
     "compiler",
     "cli",
     "lsp",
+    "dap",
 ]
 resolver = "2"

--- a/compiler/src/codegen/codegen.rs
+++ b/compiler/src/codegen/codegen.rs
@@ -1,8 +1,3 @@
-use wasm_encoder::{
-    CodeSection, ExportKind, ExportSection, Function, FunctionSection, Instruction, Module,
-    TypeSection, ValType,
-};
-
 use crate::parser::ast::Expr;
 
 pub struct CodeGenerator {}

--- a/compiler/src/lexer/lexer.rs
+++ b/compiler/src/lexer/lexer.rs
@@ -117,7 +117,7 @@ impl Lexer {
                 if self.peek() == '/' {
                     self.advance();
                     Token::Punctuation(Punctuation::Comment)
-                } else if (self.peek() == '*') {
+                } else if self.peek() == '*' {
                     self.advance();
                     Token::Punctuation(Punctuation::CommentBlkStr)
                 } else {

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -9,12 +9,15 @@ pub mod codegen;
 use crate::codegen::codegen::CodeGenerator;
 use crate::lexer::lexer::Lexer;
 use crate::parser::pratt_parser::Parser;
+use crate::semantic::analyzer::SemanticAnalyzer;
 
 pub fn compile(source: &str) -> Result<String, String> {
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize()?;
     let mut parser = Parser::new(tokens);
     let ast = parser.parse()?;
+    let mut semantic_analyzer = SemanticAnalyzer::new();
+    semantic_analyzer.analyze(&ast)?;
     let mut codegen = CodeGenerator::new();
     codegen.codegen(ast)
 }

--- a/dap/Cargo.toml
+++ b/dap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "d_dap"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+d_compiler = { path = "../compiler" }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.120"
+dap = "0.4.1-alpha1"
+anyhow = "1.0.75"

--- a/dap/src/main.rs
+++ b/dap/src/main.rs
@@ -1,0 +1,49 @@
+use std::error::Error;
+use std::io::{stdin, stdout, Read, Write};
+use dap::prelude::{Adapter, Context, Request, Response, Server, Command, ResponseBody};
+use dap::types::Capabilities;
+
+struct MyAdapter;
+
+impl Adapter for MyAdapter {
+    fn accept(&mut self, request: &Request, _ctx: &mut dyn Context) -> anyhow::Result<Response> {
+        eprintln!("Accepting request: {:?}", request);
+        match &request.command {
+            Command::Initialize(_) => {
+                let capabilities = Capabilities {
+                    supports_configuration_done_request: Some(true),
+                    ..Default::default()
+                };
+                Ok(Response::make_success(request,ResponseBody::Initialize(capabilities)))
+            }
+            _ => todo!(),
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let adapter = Box::new(MyAdapter);
+    let mut server = Server::new(adapter, stdout());
+    let mut reader = stdin();
+    let mut buffer = Vec::new();
+    loop {
+        let mut buf = [0; 1024];
+        let n = reader.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&buf[..n]);
+        let mut new_buffer = Vec::new();
+        match server.process(&buffer) {
+            Ok(Some(remaining)) => {
+                new_buffer.extend_from_slice(remaining);
+            }
+            Ok(None) => {}
+            Err(e) => {
+                eprintln!("Error: {}", e);
+            }
+        }
+        buffer = new_buffer;
+    }
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces several new features to the D-Compiler, including:

- **LSP Support:** The language server now provides diagnostics (errors and warnings) and code completion for keywords.
- **Semantic Analyzer Integration:** The semantic analyzer is now part of the compilation pipeline, enabling more robust error checking.
- **Debugger Support (Initial):** A new `dap` crate has been added to provide debugging capabilities. The initial implementation handles the `initialize` request.

I got stuck while implementing the DAP server. The `dap` crate seems to have a different API than what I expected, and I was having trouble with the `Adapter` and `Context` traits. I was in the process of reading the documentation to figure out the correct implementation.